### PR TITLE
Make router configurable

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,20 +1,22 @@
 import React, { useEffect, useState } from "react";
-import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
+import { BrowserRouter, HashRouter, Switch, Route } from "react-router-dom";
 import { Container } from "./components/Container";
 import { Navigation } from "./components/Navigation";
 import { Content } from "./components/Content";
 import "./App.css";
 import { getRoutes } from "./utils";
 
-function App() {
+function App(props) {
   const [routes, setRoutes] = useState([]);
+  const { basename = "/api-documentation", hashrouter = false } = props;
+  const Router = hashrouter ? HashRouter : BrowserRouter;
 
   useEffect(() => {
     getRoutes(setRoutes);
   }, []);
 
   return (
-    <Router basename="/api-documentation">
+    <Router basename={basename}>
       <Container>
         <Navigation />
         <Switch>

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,16 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+import * as serviceWorker from "./serviceWorker";
+
+const root = document.getElementById("root");
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <App {...root.dataset} />
   </React.StrictMode>,
-  document.getElementById('root')
+  root
 );
 
 // If you want your app to work offline and load faster, you can change


### PR DESCRIPTION
Looks like we will have to do # based routing for now, so this will make it configurable.
Nothing should change after deployment, but we can turn on via the embed like this:

```
<div id="root" data-basename="/" data-hashrouter="true"></div>
```